### PR TITLE
Fix `fix_submodules.sh`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,23 +1,19 @@
 [submodule "qmk_compiler"]
 	path = qmk_compiler
 	url = https://github.com/qmk/qmk_compiler.git
-	branch = .
 [submodule "qmk_api"]
 	path = qmk_api
 	url = https://github.com/qmk/qmk_api.git
-	branch = .
 [submodule "qmk_configurator"]
 	path = qmk_configurator
 	url = https://github.com/qmk/qmk_configurator.git
-	branch = .
 [submodule "qmk_api_tasks"]
 	path = qmk_api_tasks
 	url = https://github.com/qmk/qmk_api_tasks.git
-	branch = .
 [submodule "qmk_bot"]
 	path = qmk_bot
 	url = https://github.com/qmk/qmk_bot.git
-	branch = .
 [submodule "qmk_metrics_aggregator"]
 	path = qmk_metrics_aggregator
 	url = git@github.com:qmk/qmk_metrics_aggregator.git
+	branch = main

--- a/fix-submodules.sh
+++ b/fix-submodules.sh
@@ -3,5 +3,5 @@
 # Git clones submodules as "detached head". This fixes that so they're
 # checked out to a branch.
 
-branch_name=$(git config -f $toplevel/.gitmodules submodule.$name.branch || echo master)
+branch_name='$(git config -f $toplevel/.gitmodules submodule.$name.branch || echo master)'
 git submodule foreach -q --recursive "git checkout $branch_name"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Didn't actually respect the `branch` config and just fell back to `master` for all submodules. Since `qmk_metrics_aggregator` apparently uses `main` as the default branch, this broke.
