### PR TITLE
Do not require people to be authed with GitHub to clone submodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,5 +15,5 @@
 	url = https://github.com/qmk/qmk_bot.git
 [submodule "qmk_metrics_aggregator"]
 	path = qmk_metrics_aggregator
-	url = git@github.com:qmk/qmk_metrics_aggregator.git
+	url = https://github.com/qmk/qmk_metrics_aggregator.git
 	branch = main


### PR DESCRIPTION
Before this change, the second step in the README would fail without an SSH key associated with a GitHub account:

    $ git clone --recurse-submodules https://github.com/qmk/qmk_web_stack
    [...]
    Cloning into '/home/user/qmk_web_stack/qmk_metrics_aggregator'...
    git@github.com: Permission denied (publickey).
    fatal: Could not read from remote repository.

After merging this change into `master` in my fork, `git clone --recurse-submodules https://github.com/colons/qmk_web_stack` works fine.